### PR TITLE
Release 2.0.2 — restore host-based TED API routing

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,7 @@
                         <h3>Questions & feedback</h3>
                         <p>
                             For questions and feedback, please visit our
-                            <a href="https://github.com/OP-TED/ted-open-data-explorer/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> forum.
+                            <a href="https://github.com/OP-TED/ted-open-data/discussions" target="_blank" rel="noopener noreferrer">GitHub Discussions</a> forum.
                         </p>
                     </div>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data-explorer",
-  "version": "2.0.0",
+  "version": "2.1.0-SNAPSHOT",
   "description": "TED Open Data Explorer — Bootstrap + Vanilla JS",
   "private": true,
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ted-open-data-explorer",
-  "version": "2.1.0-SNAPSHOT",
+  "version": "2.0.2",
   "description": "TED Open Data Explorer — Bootstrap + Vanilla JS",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

Release 2.0.2 from develop. Main change: restore the host-based TED API routing that was force-flipped to acceptance in the 2.0.1 hotfix (#26).

Production CORS for `docs.ted.europa.eu` on `api.ted.europa.eu` is reportedly now in place, so this release tests that end-to-end in production. If the procedure timeline fails to load after deploy, revert this PR.

## What ships in 2.0.2

- `src/js/services/tedAPI.js` — host switch restored: `docs.ted.europa.eu` / `data.ted.europa.eu` → production API, everything else → acceptance
- `index.html` — discussions link updated to `ted-open-data` (carried over from 47e7e38)
- `package.json` — version bumped `2.0.1` → `2.0.2`

## Test plan

- [ ] After merge, wait for Pages deploy to complete
- [ ] Open https://docs.ted.europa.eu/ted-open-data-explorer/
- [ ] Look up a recent notice and confirm the procedure timeline populates (no CORS preflight error in console)
- [ ] If timeline fails: revert this PR immediately